### PR TITLE
Fix mobile layout overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -47,12 +47,13 @@ body{
   font-family:'Nunito',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
   color:var(--text);
   background: radial-gradient(1200px 800px at 70% -10%, #1b2230 0%, var(--bg) 60%);
+  overflow-x:hidden;
 }
 :root[data-theme="light"] body{
   background: radial-gradient(1200px 800px at 70% -10%, #f3f4f6 0%, var(--bg) 60%);
 }
 
-#app{ min-height:100vh; display:grid; }
+#app{ min-height:100dvh; display:grid; }
 .container{ max-width: 1100px; margin:0 auto; padding:24px; }
 
 .screen{ display:none; }
@@ -206,6 +207,35 @@ body{
   .dino-panel{ order:-1; grid-template-rows:auto auto auto auto; min-height:auto; }
   .dino-figure img{ width: clamp(140px, 48vw, 240px); }
 
+  #quiz-screen .container{
+    min-height:100dvh;
+    display:flex;
+    flex-direction:column;
+  }
+  #quiz-screen .quiz-layout{
+    flex:1;
+    display:flex;
+    flex-direction:column;
+    gap:18px;
+  }
+  #quiz-screen .quiz-main{
+    flex:1;
+    display:flex;
+    flex-direction:column;
+    gap:16px;
+  }
+  #quiz-screen .quiz-card{
+    flex:1;
+    display:flex;
+    flex-direction:column;
+  }
+  #quiz-screen .answers{
+    flex:1;
+  }
+  #quiz-screen .actions{
+    margin-top:auto;
+  }
+
   .topbar{
     grid-template-columns:1fr;
     grid-template-areas:
@@ -279,12 +309,15 @@ body{
 }
 .quiz-card h2{ margin-top:0; }
 
+.card h2{ overflow-wrap:anywhere; }
+
 .answers{ display:grid; gap:10px; margin-top:12px; }
 .answer-btn{
   appearance:none; border:1.5px solid var(--border); border-radius:12px;
   padding:12px 14px; text-align:left; cursor:pointer;
   background:#1a2230; color:var(--text);
   transition: background .12s ease, transform .06s ease, border-color .12s ease;
+  overflow-wrap:anywhere;
 }
 .answer-btn:hover{ transform: translateY(-1px); }
 .answer-btn.correct{ background: rgba(65,212,151,.15); border-color: var(--success); }


### PR DESCRIPTION
## Summary
- ensure the app uses the dynamic viewport height and hides horizontal overflow on mobile
- restructure the quiz screen layout on small devices so all elements fit within a single view without scrolling
- allow question and answer text to wrap inside their cards to avoid overflowing content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca6be91c54832e91fa99e45a0fe82e