### PR TITLE
Align dino reaction video size with static images

### DIFF
--- a/script.js
+++ b/script.js
@@ -425,8 +425,7 @@
     video.autoplay = true;
     video.muted = true;
     video.playsInline = true;
-    video.width = 360;
-    video.height = 360;
+    video.classList.add('dino-reaction');
     if (posterPng) video.setAttribute('poster', posterPng);
 
     sources.forEach(s => {

--- a/style.css
+++ b/style.css
@@ -205,7 +205,8 @@ body{
 
   .quiz-layout{ grid-template-columns:1fr; gap:18px; }
   .dino-panel{ order:-1; grid-template-rows:auto auto auto auto; min-height:auto; }
-  .dino-figure img{ width: clamp(140px, 48vw, 240px); }
+  .dino-figure img,
+  .dino-figure video{ width: clamp(140px, 48vw, 240px); }
 
   #quiz-screen .container{
     min-height:100dvh;
@@ -275,7 +276,8 @@ body{
   .lives{ gap:6px; }
   .score{ font-size:15px; }
 
-  .dino-figure img{ width: clamp(120px, 62vw, 200px); }
+  .dino-figure img,
+  .dino-figure video{ width: clamp(120px, 62vw, 200px); }
   .card h2{ font-size:20px; }
   .answer-btn{ font-size:15px; padding:12px; }
   .actions .btn{ max-width:340px; margin:0 auto; }
@@ -294,7 +296,14 @@ body{
 }
 .dino-mood-emoji{ position:absolute; right:12px; top:12px; font-size:22px; opacity:.9; }
 .dino-figure{ font-size:128px; line-height:1; transition: transform .2s ease, filter .2s ease; }
-.dino-figure img{ display:block; width: clamp(180px, 32vw, 360px); height:auto; object-fit:contain; }
+.dino-figure img,
+.dino-figure video{
+  display:block;
+  width: clamp(180px, 32vw, 360px);
+  max-width: 100%;
+  height:auto;
+  object-fit:contain;
+}
 .dino-name-big{ font-weight:800; font-size:18px; color:var(--muted); text-align:center; }
 .quiz-main{ min-width:0; }
 


### PR DESCRIPTION
## Summary
- ensure reaction videos reuse the same sizing styles as static dinosaur art
- update responsive breakpoints so video reactions stay aligned with the default figure dimensions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca6d6d3850832eb9380710aa7fe99b