### PR TITLE
Adjust mobile dino panel layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -189,7 +189,7 @@ body{
 }
 
 @media (max-width: 720px){
-  .container{ padding:20px 16px 28px; }
+  .container{ padding:16px 16px 24px; }
   .app-title{ font-size:26px; }
   .subtitle{ font-size:15px; }
 
@@ -203,8 +203,14 @@ body{
   .dino-card{ padding:16px 14px; }
   .dino-emoji{ font-size:48px; }
 
-  .quiz-layout{ grid-template-columns:1fr; gap:18px; }
-  .dino-panel{ order:-1; grid-template-rows:auto auto auto auto; min-height:auto; }
+  .quiz-layout{ grid-template-columns:1fr; gap:14px; }
+  .dino-panel{
+    order:-1;
+    grid-template-rows:auto auto auto auto;
+    min-height:auto;
+    width:100%;
+    padding:16px 14px;
+  }
   .dino-figure{ width: clamp(140px, 48vw, 240px); }
 
   #quiz-screen .container{
@@ -216,13 +222,14 @@ body{
     flex:1;
     display:flex;
     flex-direction:column;
-    gap:18px;
+    gap:16px;
+    align-items:stretch;
   }
   #quiz-screen .quiz-main{
     flex:1;
     display:flex;
     flex-direction:column;
-    gap:16px;
+    gap:14px;
   }
   #quiz-screen .quiz-card{
     flex:1;


### PR DESCRIPTION
## Summary
- stretch the dino panel to full width on mobile and keep the figure centered
- tighten mobile spacing so the action button fits within the first screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca7367fee0832ebb811d884b816356