### PR TITLE
Adjust mobile quiz topbar layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -244,22 +244,22 @@ body{
   }
 
   .topbar{
-    grid-template-columns:1fr;
+    grid-template-columns: auto 1fr auto auto;
     grid-template-areas:
-      "badge"
-      "progress"
-      "lives"
-      "score"
-      "toggles"
-      "exit";
-    row-gap:10px;
+      "badge badge badge badge"
+      "progress progress progress progress"
+      "lives score toggles exit";
+    row-gap:12px;
+    column-gap:10px;
+    align-items:center;
   }
   .topbar > *{ justify-self:stretch; }
   .topbar > .progress{ min-width:0; }
-  .topbar > .score{ text-align:left; }
-  .topbar > .toggles{ justify-self:start; }
-  .topbar .toggle-wrap{ align-items:start; }
-  .topbar > #exit-btn{ justify-self:stretch; }
+  .topbar > .score{ text-align:left; justify-self:start; }
+  .topbar > .toggles{ justify-self:start; display:flex; gap:8px; }
+  .topbar .toggle-wrap{ align-items:center; display:flex; }
+  .topbar .toggle-label{ display:none; }
+  .topbar > #exit-btn{ justify-self:end; }
 
   .card{ padding:16px; }
   .answers{ gap:12px; }


### PR DESCRIPTION
## Summary
- update the mobile breakpoint grid for the quiz topbar so lives, bonuses, toggles, and exit share a single row
- hide toggle labels and adjust spacing to keep controls compact on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca75b39e24832e8aee22369c1f8c4b