### PR TITLE
Adjust quiz language toggle visibility and next button size

### DIFF
--- a/script.js
+++ b/script.js
@@ -696,9 +696,22 @@
   }
 
   // ===== Утилиты =====
+  function setLanguageToggleVisibility(shouldShow) {
+    const hide = !shouldShow;
+    languageToggleBtns.forEach(btn => {
+      const wrap = btn.closest('.toggle-wrap');
+      if (wrap) {
+        wrap.classList.toggle('hidden', hide);
+      } else {
+        btn.classList.toggle('hidden', hide);
+      }
+    });
+  }
+
   function showScreen(screen) {
     [startScreen, quizScreen, failScreen, resultScreen].forEach(s => s.classList.remove('active'));
     screen.classList.add('active');
+    setLanguageToggleVisibility(screen === startScreen);
     // 🔄 Обновляем индикацию звука/темы на всех экранах
     syncToggleButtons();
   }

--- a/style.css
+++ b/style.css
@@ -137,6 +137,12 @@ body{
 .btn.small{ padding:8px 12px; font-size:14px; line-height:1.2; display:inline-flex; align-items:center; gap:6px; }
 .icon-btn{ padding:8px 10px; border-radius:10px; }
 
+@media (min-width: 721px){
+  #quiz-screen #next-btn{
+    min-width:300px;
+  }
+}
+
 /* ---------- Topbar (two-row) ---------- */
 .topbar{
   display:grid;


### PR DESCRIPTION
## Summary
- enlarge the quiz "Next" button on desktop layouts to make it more prominent
- hide the language toggle while the player is in-game or viewing results, leaving it only on the start screen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca80f6c6f0832e84c80631ee769295